### PR TITLE
Default to UUIDs in migration

### DIFF
--- a/lib/generators/devise_sessionable/install/templates/migration.rb
+++ b/lib/generators/devise_sessionable/install/templates/migration.rb
@@ -1,6 +1,6 @@
 class DeviseSessionableCreateSessions < ActiveRecord::Migration
   def change
-    create_table :devise_sessionable_sessions do |t|
+    create_table :devise_sessionable_sessions, id: :uuid do |t|
       t.string :authentication_token
       t.uuid :authable_id, null: false
       t.string :authable_type, null: false
@@ -11,6 +11,6 @@ class DeviseSessionableCreateSessions < ActiveRecord::Migration
     add_index :devise_sessionable_sessions,
               [:authable_id, :authable_type],
               name: 'index_devise_sessionable_sessions_on_authable'
-    add_index :devise_sessionable_sessions, :authentication_token, unique: true
+    add_index :devise_sessionable_sessions, :authentication_token
   end
 end


### PR DESCRIPTION
Related to #2, but does not close it. Migration now defaults to `uuid` rather than integer id. Change is reflected in README